### PR TITLE
Add Spotify support to music player

### DIFF
--- a/exe/sha_conf.docker.example.json
+++ b/exe/sha_conf.docker.example.json
@@ -27,6 +27,8 @@
                                                 // best setting is typically between 1/3 and 1/2 of STREAM_BUFFER_SIZE amount
     "YTDLP_UTIL_EXE": "/home/musicat/ytdlp.py",
     "YTDLP_LIB_DIR": "/home/musicat/yt-dlp/",
+    "SPOTIFY_CLIENT_ID": "",
+    "SPOTIFY_CLIENT_SECRET": "",
     "ADMIN_IDS": [
       750335181285490760
     ], // access to bot /owner commands

--- a/exe/sha_conf.docker.example.json
+++ b/exe/sha_conf.docker.example.json
@@ -27,7 +27,7 @@
                                                 // best setting is typically between 1/3 and 1/2 of STREAM_BUFFER_SIZE amount
     "YTDLP_UTIL_EXE": "/home/musicat/ytdlp.py",
     "YTDLP_LIB_DIR": "/home/musicat/yt-dlp/",
-    "SPOTIFY_CLIENT_ID": "",
+    "SPOTIFY_CLIENT_ID": "", // leave blank to disable Spotify
     "SPOTIFY_CLIENT_SECRET": "",
     "ADMIN_IDS": [
       750335181285490760

--- a/exe/sha_conf.example.json
+++ b/exe/sha_conf.example.json
@@ -27,7 +27,7 @@
                                                 // best setting is typically between 1/3 and 1/2 of STREAM_BUFFER_SIZE amount
     "YTDLP_UTIL_EXE": "../src/yt-dlp/ytdlp.py", // assumed working directory is in exe/ dir, provide absolute path so it's valid to run regardless of working directory
     "YTDLP_LIB_DIR": "../libs/yt-dlp/",         // assumed working directory is in exe/ dir, provide absolute path so it's valid to run regardless of working directory
-    "SPOTIFY_CLIENT_ID": "", // Spotify client id
+    "SPOTIFY_CLIENT_ID": "", // Spotify client id (leave blank to disable Spotify)
     "SPOTIFY_CLIENT_SECRET": "", // Spotify client secret
     "ADMIN_IDS": [
       750335181285490760

--- a/exe/sha_conf.example.json
+++ b/exe/sha_conf.example.json
@@ -27,6 +27,8 @@
                                                 // best setting is typically between 1/3 and 1/2 of STREAM_BUFFER_SIZE amount
     "YTDLP_UTIL_EXE": "../src/yt-dlp/ytdlp.py", // assumed working directory is in exe/ dir, provide absolute path so it's valid to run regardless of working directory
     "YTDLP_LIB_DIR": "../libs/yt-dlp/",         // assumed working directory is in exe/ dir, provide absolute path so it's valid to run regardless of working directory
+    "SPOTIFY_CLIENT_ID": "", // Spotify client id
+    "SPOTIFY_CLIENT_SECRET": "", // Spotify client secret
     "ADMIN_IDS": [
       750335181285490760
     ], // access to bot /owner commands

--- a/include/musicat/musicat.h
+++ b/include/musicat/musicat.h
@@ -148,6 +148,9 @@ std::string get_ytdlp_util_exe ();
 
 std::string get_ytdlp_lib_path ();
 
+std::string get_spotify_client_id ();
+std::string get_spotify_client_secret ();
+
 /**
  * @brief Search _find inside _vec
  *

--- a/include/musicat/util/spotify_api.h
+++ b/include/musicat/util/spotify_api.h
@@ -1,0 +1,25 @@
+#ifndef MUSICAT_UTIL_SPOTIFY_API_H
+#define MUSICAT_UTIL_SPOTIFY_API_H
+
+#include <string>
+#include <vector>
+
+namespace musicat::util::spotify_api {
+
+struct Track {
+    std::string artist;
+    std::string title;
+};
+
+std::string authenticate(const std::string &client_id,
+                         const std::string &client_secret);
+
+std::vector<Track> fetch_tracks(const std::string &url_or_id,
+                                const std::string &access_token);
+std::vector<Track> fetch_tracks(const std::string &url_or_id,
+                                const std::string &client_id,
+                                const std::string &client_secret);
+
+} // namespace musicat::util::spotify_api
+
+#endif // MUSICAT_UTIL_SPOTIFY_API_H

--- a/src/musicat/cmds/play.cpp
+++ b/src/musicat/cmds/play.cpp
@@ -48,7 +48,7 @@ get_register_obj (const dpp::snowflake &sha_id)
                               sha_id)
         .add_option (
             dpp::command_option (dpp::co_string, "query",
-                                 "Song [to search] or Youtube URL [to play]")
+                                 "Song [to search] or Youtube/Spotify URL")
                 .set_auto_complete (true)
                 .set_max_length (150))
         .add_option (create_yes_no_option (

--- a/src/musicat/player_manager_util.cpp
+++ b/src/musicat/player_manager_util.cpp
@@ -333,8 +333,13 @@ find_track (const bool playlist, const std::string &arg_query,
 {
     std::string trimmed_query = util::trim_str (arg_query);
 
+    std::string sp_id = get_spotify_client_id ();
+    std::string sp_secret = get_spotify_client_secret ();
+    bool spotify_enabled = !sp_id.empty () && !sp_secret.empty ();
+
     std::regex sp_re(R"((?:spotify[/:]|open\.spotify\.com/)(track|playlist)[/:])");
-    bool is_spotify = std::regex_search(trimmed_query, sp_re);
+    bool is_spotify = spotify_enabled &&
+                      std::regex_search(trimmed_query, sp_re);
 
 #ifdef USE_SEARCH_CACHE
     bool has_cache_id = !cache_id.empty ();
@@ -387,9 +392,9 @@ find_track (const bool playlist, const std::string &arg_query,
                 {
                     if (is_spotify)
                         {
-                            auto sp_tracks = spotify_api::fetch_tracks (
-                                trimmed_query, get_spotify_client_id (),
-                                get_spotify_client_secret ());
+                            auto sp_tracks =
+                                spotify_api::fetch_tracks (
+                                    trimmed_query, sp_id, sp_secret);
 
                             for (const auto &t : sp_tracks)
                                 {

--- a/src/musicat/player_manager_util.cpp
+++ b/src/musicat/player_manager_util.cpp
@@ -6,6 +6,7 @@
 #include "musicat/player_manager_timer.h"
 #include "musicat/thread_manager.h"
 #include "musicat/util.h"
+#include "musicat/util/spotify_api.h"
 #include "musicat/util_response.h"
 #include <dirent.h>
 #include <libpq-fe.h>
@@ -332,6 +333,9 @@ find_track (const bool playlist, const std::string &arg_query,
 {
     std::string trimmed_query = util::trim_str (arg_query);
 
+    std::regex sp_re(R"((?:spotify[/:]|open\.spotify\.com/)(track|playlist)[/:])");
+    bool is_spotify = std::regex_search(trimmed_query, sp_re);
+
 #ifdef USE_SEARCH_CACHE
     bool has_cache_id = !cache_id.empty ();
 #else
@@ -381,15 +385,33 @@ find_track (const bool playlist, const std::string &arg_query,
         {
             try
                 {
-                    searches
-                        = playlist
-                              ? (playlist_result
-                                 = yt_search::get_playlist (trimmed_query))
-                                    .entries ()
+                    if (is_spotify)
+                        {
+                            auto sp_tracks = spotify_api::fetch_tracks (
+                                trimmed_query, get_spotify_client_id (),
+                                get_spotify_client_secret ());
 
-                              : (search_result
-                                 = yt_search::search (trimmed_query))
-                                    .trackResults ();
+                            for (const auto &t : sp_tracks)
+                                {
+                                    std::string q = t.artist + " " + t.title;
+                                    auto r = yt_search::search (q);
+                                    if (!r.trackResults ().empty ())
+                                        searches.push_back (
+                                            r.trackResults ().front ());
+                                }
+                        }
+                    else
+                        {
+                            searches
+                                = playlist
+                                      ? (playlist_result
+                                         = yt_search::get_playlist (trimmed_query))
+                                            .entries ()
+
+                                      : (search_result
+                                         = yt_search::search (trimmed_query))
+                                            .trackResults ();
+                        }
 
                     searches_size = searches.size ();
 

--- a/src/musicat/run.cpp
+++ b/src/musicat/run.cpp
@@ -438,6 +438,18 @@ get_ytdlp_lib_path ()
     return get_config_value<std::string> ("YTDLP_LIB_DIR", "");
 }
 
+std::string
+get_spotify_client_id ()
+{
+    return get_config_value<std::string> ("SPOTIFY_CLIENT_ID", "");
+}
+
+std::string
+get_spotify_client_secret ()
+{
+    return get_config_value<std::string> ("SPOTIFY_CLIENT_SECRET", "");
+}
+
 std::vector<std::string>
 get_cors_enabled_origins ()
 {

--- a/src/musicat/util/spotify_api.cpp
+++ b/src/musicat/util/spotify_api.cpp
@@ -1,0 +1,119 @@
+#include "musicat/util/spotify_api.h"
+#include "musicat/util/base64.h"
+#include <curlpp/Easy.hpp>
+#include <curlpp/Options.hpp>
+#include <nlohmann/json.hpp>
+#include <regex>
+#include <sstream>
+
+namespace musicat::util::spotify_api {
+
+static std::string
+request(const std::string &url, const std::list<std::string> &headers,
+        const std::string &post)
+{
+    curlpp::Easy req;
+    std::ostringstream os;
+    req.setOpt(curlpp::options::Url(url));
+    req.setOpt(curlpp::options::WriteStream(&os));
+    if (!headers.empty())
+        req.setOpt(curlpp::options::HttpHeader(headers));
+    if (!post.empty()) {
+        req.setOpt(curlpp::options::PostFields(post));
+        req.setOpt(curlpp::options::PostFieldSize(post.size()));
+    }
+    req.perform();
+    return os.str();
+}
+
+std::string
+authenticate(const std::string &client_id, const std::string &client_secret)
+{
+    std::string creds = client_id + ":" + client_secret;
+    std::string auth =
+        "Authorization: Basic " + util::base64::encode_standard(creds);
+    std::list<std::string> headers = {
+        "Content-Type: application/x-www-form-urlencoded", auth };
+    std::string body = "grant_type=client_credentials";
+    auto res = request("https://accounts.spotify.com/api/token", headers, body);
+    auto j = nlohmann::json::parse(res, nullptr, false);
+    if (!j.is_object())
+        return "";
+    return j.value("access_token", "");
+}
+
+static bool
+parse_url(const std::string &url, std::string &type, std::string &id)
+{
+    std::regex r(R"((?:spotify[/:]|open\.spotify\.com/)(track|playlist)[/:]([^?\n]+))");
+    std::smatch m;
+    if (std::regex_search(url, m, r)) {
+        type = m[1].str();
+        id = m[2].str();
+        return true;
+    }
+    return false;
+}
+
+std::vector<Track>
+fetch_tracks(const std::string &url_or_id, const std::string &access_token)
+{
+    std::string type;
+    std::string id;
+    if (!parse_url(url_or_id, type, id))
+        return {};
+
+    std::list<std::string> headers = { "Authorization: Bearer " + access_token };
+    std::vector<Track> out;
+
+    if (type == "track") {
+        std::string url =
+            "https://api.spotify.com/v1/tracks/" + id +
+            "?fields=name,artists(name)";
+        auto res = request(url, headers, "");
+        auto j = nlohmann::json::parse(res, nullptr, false);
+        if (j.is_object()) {
+            Track t;
+            t.title = j.value("name", "");
+            if (j.contains("artists") && j["artists"].is_array() &&
+                j["artists"].size() > 0)
+                t.artist = j["artists"][0].value("name", "");
+            if (!t.title.empty())
+                out.push_back(t);
+        }
+    } else if (type == "playlist") {
+        std::string url =
+            "https://api.spotify.com/v1/playlists/" + id +
+            "/tracks?fields=items(track(name,artists(name)))&limit=100";
+        auto res = request(url, headers, "");
+        auto j = nlohmann::json::parse(res, nullptr, false);
+        if (j.contains("items") && j["items"].is_array()) {
+            for (auto &it : j["items"]) {
+                if (!it.contains("track"))
+                    continue;
+                auto &tr = it["track"];
+                Track t;
+                t.title = tr.value("name", "");
+                if (tr.contains("artists") && tr["artists"].is_array() &&
+                    tr["artists"].size() > 0)
+                    t.artist = tr["artists"][0].value("name", "");
+                if (!t.title.empty())
+                    out.push_back(t);
+            }
+        }
+    }
+    return out;
+}
+
+std::vector<Track>
+fetch_tracks(const std::string &url_or_id, const std::string &client_id,
+             const std::string &client_secret)
+{
+    auto token = authenticate(client_id, client_secret);
+    if (token.empty())
+        return {};
+    return fetch_tracks(url_or_id, token);
+}
+
+} // namespace musicat::util::spotify_api
+


### PR DESCRIPTION
## Summary
- implement a minimal Spotify Web API helper using curlpp
- fetch Spotify track/playlist info when URLs are detected
- search fetched songs on YouTube and add them to the queue
- expose Spotify credential helpers in `musicat` API
- allow `/play` command to accept Spotify links
- document new config fields for Spotify credentials

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6842bc680cc48327a97f200057850323