### PR TITLE
Add Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,35 @@
+name: Build and Push Docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/shasha/musicat:latest
+            ghcr.io/shasha/musicat:${{ github.sha }}
+

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ docker container start Musicat
 cat docker.sh
 ```
 
+### GitHub Actions Docker Workflow
+
+This repository includes a workflow that builds and pushes the Docker image to GitHub Container Registry. Authentication uses the built-in `GITHUB_TOKEN`, so no additional secrets are required.
+
+
 ## Installing Dependencies
 
 Ubuntu 22.04.2 LTS:


### PR DESCRIPTION
## Summary
- build Docker image on pushes to `main` and tags
- push image to GitHub Container Registry using `GITHUB_TOKEN`
- document that no extra secrets are required

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842c3e6f3c083279b42711577bb9e5d