### PR TITLE
Fix Docker music folder permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ USER musicat
 
 WORKDIR /home/musicat
 
+# create music directory with proper permissions
+RUN mkdir -p /home/musicat/music && \
+    chown musicat:musicat /home/musicat/music
+
 COPY --chown=musicat:musicat --from=build \
              /app/build/Shasha \
              /app/build/libs/DPP/library/libdpp.so* \

--- a/README.md
+++ b/README.md
@@ -163,9 +163,16 @@ mv Shasha ../exe
 # register the commands
 ./Shasha reg g
 
+
 # run the bot
 ./Shasha
 ```
+
+### Enabling Spotify support
+
+To play tracks or playlists from Spotify links, create a Spotify application and
+add your `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` values to
+`sha_conf.json`. Leave these fields empty to disable Spotify integration.
 
 ### Compiling with clang
 

--- a/src/musicat/cmds/download.cpp
+++ b/src/musicat/cmds/download.cpp
@@ -110,6 +110,9 @@ slash_run (const dpp::slashcommand_t &event)
                         return;
                     case 0:
                         break;
+                    case 3:
+                        event.edit_response ("Spotify support not configured");
+                        return;
                     default:
                         fprintf (
                             stderr,

--- a/src/musicat/player_manager_util.cpp
+++ b/src/musicat/player_manager_util.cpp
@@ -338,8 +338,12 @@ find_track (const bool playlist, const std::string &arg_query,
     bool spotify_enabled = !sp_id.empty () && !sp_secret.empty ();
 
     std::regex sp_re(R"((?:spotify[/:]|open\.spotify\.com/)(track|playlist)[/:])");
-    bool is_spotify = spotify_enabled &&
-                      std::regex_search(trimmed_query, sp_re);
+    bool is_spotify_url = std::regex_search(trimmed_query, sp_re);
+
+    if (is_spotify_url && !spotify_enabled)
+        return { {}, 3 };
+
+    bool is_spotify = spotify_enabled && is_spotify_url;
 
 #ifdef USE_SEARCH_CACHE
     bool has_cache_id = !cache_id.empty ();
@@ -638,6 +642,12 @@ add_track (bool playlist, dpp::snowflake guild_id, std::string arg_query,
                     break;
 
                 event.edit_response ("Error while searching, try again");
+                return;
+            case 3:
+                if (!from_interaction)
+                    break;
+
+                event.edit_response ("Spotify support not configured");
                 return;
             default:
                 fprintf (stderr,


### PR DESCRIPTION
## Summary
- ensure `/home/musicat/music` exists and is writable for the musicat user
- add Spotify disabled notice when credentials are missing
- document how to enable Spotify

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842ed1e9af08327b35e82db4cafdc93