### PR TITLE
Improve Spotify lookup for yt-dlp flow

### DIFF
--- a/src/musicat/player_manager_util.cpp
+++ b/src/musicat/player_manager_util.cpp
@@ -333,12 +333,15 @@ find_track (const bool playlist, const std::string &arg_query,
 {
     std::string trimmed_query = util::trim_str (arg_query);
 
+    const bool debug = get_debug_state ();
+
     std::string sp_id = get_spotify_client_id ();
     std::string sp_secret = get_spotify_client_secret ();
     bool spotify_enabled = !sp_id.empty () && !sp_secret.empty ();
 
-    std::regex sp_re(R"((?:spotify[/:]|open\.spotify\.com/)(track|playlist)[/:])");
-    bool is_spotify_url = std::regex_search(trimmed_query, sp_re);
+    std::regex sp_re (
+        R"((?:spotify[/:]|open\.spotify\.com/)(track|playlist)[/:])");
+    bool is_spotify_url = std::regex_search (trimmed_query, sp_re);
 
     if (is_spotify_url && !spotify_enabled)
         return { {}, 3 };
@@ -396,9 +399,13 @@ find_track (const bool playlist, const std::string &arg_query,
                 {
                     if (is_spotify)
                         {
-                            auto sp_tracks =
-                                spotify_api::fetch_tracks (
-                                    trimmed_query, sp_id, sp_secret);
+                            if (debug)
+                                fprintf (stderr,
+                                         "[find_track] Spotify query: %s\n",
+                                         trimmed_query.c_str ());
+
+                            auto sp_tracks = spotify_api::fetch_tracks (
+                                trimmed_query, sp_id, sp_secret);
 
                             for (const auto &t : sp_tracks)
                                 {
@@ -414,7 +421,8 @@ find_track (const bool playlist, const std::string &arg_query,
                             searches
                                 = playlist
                                       ? (playlist_result
-                                         = yt_search::get_playlist (trimmed_query))
+                                         = yt_search::get_playlist (
+                                             trimmed_query))
                                             .entries ()
 
                                       : (search_result
@@ -435,7 +443,13 @@ find_track (const bool playlist, const std::string &arg_query,
             catch (std::exception &e)
                 {
                     std::cerr << "[player::find_track ERROR] " << guild_id
-                              << ':' << e.what () << '\n';
+                              << ':' << e.what ();
+
+                    if (is_spotify)
+                        std::cerr << " (Spotify query: " << trimmed_query
+                                  << ')';
+
+                    std::cerr << '\n';
 
                     return { {}, 1 };
                 }
@@ -454,13 +468,41 @@ find_track (const bool playlist, const std::string &arg_query,
     // use mctrack::fetch
     // playlist true means autoplay request, which is always a playlist url
     // query
-    nlohmann::json res = mctrack::fetch (
-        { trimmed_query, YDLP_DEFAULT_MAX_ENTRIES, playlist });
+    if (is_spotify)
+        {
+            if (debug)
+                fprintf (stderr, "[find_track] Spotify query: %s\n",
+                         trimmed_query.c_str ());
 
-    if (res.is_null ())
-        return { {}, 2 };
+            auto sp_tracks
+                = spotify_api::fetch_tracks (trimmed_query, sp_id, sp_secret);
 
-    searches = YTDLPTrack::get_playlist_entries (res);
+            for (const auto &t : sp_tracks)
+                {
+                    std::string q = t.artist + " " + t.title;
+
+                    nlohmann::json res
+                        = mctrack::fetch ( { q, 1, false } );
+
+                    if (res.is_null ())
+                        continue;
+
+                    auto entries = YTDLPTrack::get_playlist_entries (res);
+                    if (!entries.empty ())
+                        searches.push_back (entries.front ());
+                }
+        }
+    else
+        {
+            nlohmann::json res
+                = mctrack::fetch ( { trimmed_query, YDLP_DEFAULT_MAX_ENTRIES,
+                                     playlist } );
+
+            if (res.is_null ())
+                return { {}, 2 };
+
+            searches = YTDLPTrack::get_playlist_entries (res);
+        }
 
 #endif
 
@@ -474,6 +516,11 @@ find_track (const bool playlist, const std::string &arg_query,
 
     if (searches.begin () == searches.end ())
         {
+            if (debug && is_spotify)
+                fprintf (stderr,
+                         "[find_track] Spotify query yielded no results: %s\n",
+                         trimmed_query.c_str ());
+
             return { {}, -1 };
         }
 

--- a/src/musicat/util/spotify_api.cpp
+++ b/src/musicat/util/spotify_api.cpp
@@ -1,5 +1,7 @@
 #include "musicat/util/spotify_api.h"
 #include "musicat/util/base64.h"
+#include "musicat/musicat.h"
+#include <list>
 #include <curlpp/Easy.hpp>
 #include <curlpp/Options.hpp>
 #include <nlohmann/json.hpp>
@@ -22,7 +24,17 @@ request(const std::string &url, const std::list<std::string> &headers,
         req.setOpt(curlpp::options::PostFields(post));
         req.setOpt(curlpp::options::PostFieldSize(post.size()));
     }
-    req.perform();
+    if (get_debug_state())
+        fprintf(stderr, "[spotify_api] %s %s\n", post.empty() ? "GET" : "POST",
+                url.c_str());
+
+    try {
+        req.perform();
+    } catch (std::exception &e) {
+        fprintf(stderr, "[spotify_api ERROR] %s: %s\n", url.c_str(), e.what());
+        return "";
+    }
+
     return os.str();
 }
 

--- a/src/musicat/util/spotify_api.cpp
+++ b/src/musicat/util/spotify_api.cpp
@@ -25,17 +25,19 @@ request(const std::string &url, const std::list<std::string> &headers,
         req.setOpt(curlpp::options::PostFieldSize(post.size()));
     }
     if (get_debug_state())
-        fprintf(stderr, "[spotify_api] %s %s\n", post.empty() ? "GET" : "POST",
-                url.c_str());
+        fprintf(stderr, "[spotify_api] %s %s\n",
+                post.empty() ? "GET" : "POST", url.c_str());
 
     try {
         req.perform();
+        std::string res = os.str();
+        if (get_debug_state())
+            fprintf(stderr, "[spotify_api] response: %s\n", res.c_str());
+        return res;
     } catch (std::exception &e) {
         fprintf(stderr, "[spotify_api ERROR] %s: %s\n", url.c_str(), e.what());
         return "";
     }
-
-    return os.str();
 }
 
 std::string


### PR DESCRIPTION
## Summary
- handle Spotify links when yt-dlp is used for track searches

## Testing
- `cmake ..` *(fails: libs/DPP does not contain a CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_6842f76d73a08327bc43f3bee103de73